### PR TITLE
Implement puzzle validation handler

### DIFF
--- a/internal/handlers/login.go
+++ b/internal/handlers/login.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+var sessions = map[string]string{}
+
 func LoginHandler(c *gin.Context) {
 	var input LoginInput
 	if err := c.ShouldBindJSON(&input); err != nil {

--- a/internal/handlers/puzzle.go
+++ b/internal/handlers/puzzle.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/isdiemer/crossword-backend/internal/service"
+)
+
+// PuzzleValidationInput defines the expected input JSON for validation.
+type PuzzleValidationInput struct {
+	Grid [][]string `json:"grid" binding:"required"`
+}
+
+// ValidatePuzzle handles POST /puzzles/:id/validate requests.
+func ValidatePuzzle(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid puzzle id"})
+		return
+	}
+
+	var input PuzzleValidationInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid input"})
+		return
+	}
+	ok, err := service.CheckPuzzleSolution(uint(id), input.Grid)
+	if err != nil {
+		if err == service.ErrPuzzleNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"correct": ok})
+}

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -8,4 +8,5 @@ func RegisterRoutes(r *gin.Engine) {
 	r.GET("/ping", PingHandler)
 	r.POST("/register", RegisterUser)
 	r.POST("/login", LoginHandler)
+	r.POST("/puzzles/:id/validate", ValidatePuzzle)
 }

--- a/internal/model/puzzle.go
+++ b/internal/model/puzzle.go
@@ -1,9 +1,13 @@
 package model
 
+import "time"
+
+// Puzzle represents a crossword puzzle. The Grid field stores the solved
+// puzzle state. It is serialized as JSON in the database.
 type Puzzle struct {
-	ID      int               `json:"id"`
-	Title   string            `json:"title"`
-	Grid    [][]string        `json:"grid"`
-	Clues   map[string]string `json:"Clues"`
-	Created string            `json:"Created"`
+	ID        uint              `gorm:"primaryKey" json:"id"`
+	Title     string            `json:"title"`
+	Grid      string            `json:"grid"`
+	Clues     map[string]string `gorm:"-" json:"clues"`
+	CreatedAt time.Time         `json:"created"`
 }

--- a/internal/service/puzzle.go
+++ b/internal/service/puzzle.go
@@ -1,1 +1,77 @@
 package service
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/isdiemer/crossword-backend/internal/storage"
+	"gorm.io/gorm"
+)
+
+// ErrPuzzleNotFound indicates the requested puzzle does not exist.
+var ErrPuzzleNotFound = errors.New("puzzle not found")
+
+// ValidatePuzzle checks if the provided grid is well formed.
+// It currently performs simple validation ensuring that:
+//   - the grid is not empty
+//   - all rows have the same length
+//   - each cell contains at most one character
+func ValidatePuzzle(grid [][]string) error {
+	if len(grid) == 0 {
+		return errors.New("grid cannot be empty")
+	}
+
+	rowLen := len(grid[0])
+	if rowLen == 0 {
+		return errors.New("grid rows cannot be empty")
+	}
+
+	for i, row := range grid {
+		if len(row) != rowLen {
+			return fmt.Errorf("row %d has incorrect length", i)
+		}
+		for j, cell := range row {
+			if len(cell) > 1 {
+				return fmt.Errorf("cell (%d,%d) has more than one character", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+// CheckPuzzleSolution fetches a puzzle by ID and compares the provided guess
+// grid against the stored solution. It returns true when every cell matches.
+func CheckPuzzleSolution(id uint, guess [][]string) (bool, error) {
+	puzzle, err := storage.GetPuzzleByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, ErrPuzzleNotFound
+		}
+		return false, err
+	}
+
+	var solution [][]string
+	if err := json.Unmarshal([]byte(puzzle.Grid), &solution); err != nil {
+		return false, fmt.Errorf("invalid stored grid")
+	}
+
+	if err := ValidatePuzzle(guess); err != nil {
+		return false, err
+	}
+
+	if len(solution) != len(guess) {
+		return false, fmt.Errorf("grid size mismatch")
+	}
+	for i := range solution {
+		if len(solution[i]) != len(guess[i]) {
+			return false, fmt.Errorf("grid size mismatch")
+		}
+		for j := range solution[i] {
+			if solution[i][j] != guess[i][j] {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/internal/service/puzzle_test.go
+++ b/internal/service/puzzle_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/isdiemer/crossword-backend/internal/model"
+	"github.com/isdiemer/crossword-backend/internal/storage"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestValidatePuzzle_Valid(t *testing.T) {
+	grid := [][]string{{"a", "b"}, {"c", "d"}}
+	if err := ValidatePuzzle(grid); err != nil {
+		t.Fatalf("expected valid grid, got error: %v", err)
+	}
+}
+
+func TestValidatePuzzle_Empty(t *testing.T) {
+	if err := ValidatePuzzle(nil); err == nil {
+		t.Fatalf("expected error for empty grid")
+	}
+}
+
+func TestValidatePuzzle_RowLength(t *testing.T) {
+	grid := [][]string{{"a"}, {"b", "c"}}
+	if err := ValidatePuzzle(grid); err == nil {
+		t.Fatalf("expected row length error")
+	}
+}
+
+func TestValidatePuzzle_CellLength(t *testing.T) {
+	grid := [][]string{{"ab"}}
+	if err := ValidatePuzzle(grid); err == nil {
+		t.Fatalf("expected cell length error")
+	}
+}
+
+func TestCheckPuzzleSolution(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	storage.DB = db
+	db.AutoMigrate(&model.Puzzle{})
+
+	puzzle := model.Puzzle{Title: "test", Grid: `[["a"]]`}
+	db.Create(&puzzle)
+
+	ok, err := CheckPuzzleSolution(puzzle.ID, [][]string{{"a"}})
+	if err != nil || !ok {
+		t.Fatalf("expected correct solution")
+	}
+
+	ok, err = CheckPuzzleSolution(puzzle.ID, [][]string{{"b"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected mismatch")
+	}
+}
+
+func TestCheckPuzzleSolution_NotFound(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	storage.DB = db
+	db.AutoMigrate(&model.Puzzle{})
+
+	_, err := CheckPuzzleSolution(1, [][]string{{"a"}})
+	if err != ErrPuzzleNotFound {
+		t.Fatalf("expected ErrPuzzleNotFound, got %v", err)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -17,7 +17,7 @@ func InitDatabase() {
 		log.Fatal("failed to connect database:", err)
 	}
 
-	err = DB.AutoMigrate(&model.User{})
+	err = DB.AutoMigrate(&model.User{}, &model.Puzzle{})
 	if err != nil {
 		log.Fatal("failed to migrate database:", err)
 	}

--- a/internal/storage/puzzle.go
+++ b/internal/storage/puzzle.go
@@ -1,0 +1,12 @@
+package storage
+
+import "github.com/isdiemer/crossword-backend/internal/model"
+
+func GetPuzzleByID(id uint) (*model.Puzzle, error) {
+	var p model.Puzzle
+	result := DB.First(&p, id)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &p, nil
+}


### PR DESCRIPTION
## Summary
- add puzzle model with database fields
- migrate puzzle table on startup
- validate user guesses against saved puzzle grids
- provide storage helper to fetch puzzles
- expand tests to cover solution checking
- handle puzzle not found error in service and handler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b80adb4308320ae4190bc368b95d0