### PR TITLE
Fix CORS list and cookie options

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,18 +43,24 @@ func buildCORS() cors.Config {
 	}
 
 	// Exact-match origins from env (comma-separated)
-	exact := map[string]struct{}{
-		"https://crossword-frontend-one.vercel.app": struct{}{},
-	}
+	exact := map[string]struct{}{}
+	allowOrigins := []string{"https://crossword-frontend-one.vercel.app"}
+	exact["https://crossword-frontend-one.vercel.app"] = struct{}{}
 	if v := os.Getenv("ALLOWED_ORIGINS"); v != "" {
 		for _, o := range strings.Split(v, ",") {
 			o = strings.TrimSpace(o)
+			if o == "" {
+				continue
+			}
 			exact[o] = struct{}{}
+			allowOrigins = append(allowOrigins, o)
 			log.Printf("Added allowed origin: %s", o)
 		}
 	} else {
 		log.Printf("Warning: No ALLOWED_ORIGINS environment variable set, using default Vercel domain")
 	}
+
+	cfg.AllowOrigins = allowOrigins
 
 	cfg.AllowOriginFunc = func(origin string) bool {
 		// Log the incoming origin

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -50,7 +50,7 @@ func LoginHandler(c *gin.Context) {
 	// Extract domain from origin
 	var domain string
 	if strings.Contains(origin, "vercel.app") {
-		domain = ".vercel.app" // Note the leading dot for cross-subdomain support
+		domain = ".vercel.app" // cross-subdomain support
 	} else {
 		domain = os.Getenv("COOKIE_DOMAIN")
 	}
@@ -60,23 +60,20 @@ func LoginHandler(c *gin.Context) {
 	cookieValue := token
 	maxAge := 3600
 	path := "/"
-	secure := true
+	secure := strings.HasPrefix(origin, "https")
 	httpOnly := true
 
-	// Create a new cookie instance
-	cookie := &http.Cookie{
-		Name:     cookieName,
-		Value:    cookieValue,
-		Path:     path,
-		Domain:   domain,
-		MaxAge:   maxAge,
-		Secure:   secure,
-		HttpOnly: httpOnly,
-		SameSite: http.SameSiteNoneMode,
-	}
-
-	// Set the cookie using http.SetCookie
-	http.SetCookie(c.Writer, cookie)
+	// Set the cookie using Gin helper
+	c.SetSameSite(http.SameSiteNoneMode)
+	c.SetCookie(
+		cookieName,
+		cookieValue,
+		maxAge,
+		path,
+		domain,
+		secure,
+		httpOnly,
+	)
 
 	// Log response headers
 	log.Printf("Response headers being set:")


### PR DESCRIPTION
## Summary
- tweak the CORS builder so a list of allowed origins is populated
- use `gin.Context.SetCookie` so the session cookie respects request origin protocol

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686090ffe9c48320b798c1b33bb52805