### PR TITLE
Add handshake interstitial for Safari

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -85,9 +85,3 @@ func DeleteHandler(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "account deleted"})
 }
-func HandShakeHandler(c *gin.Context) {
-	c.Redirect(
-		307,
-		"https://crossword-frontend-one.vercel.app",
-	)
-}

--- a/internal/handlers/handshake.go
+++ b/internal/handlers/handshake.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func HandshakeGet(c *gin.Context) {
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	c.String(http.StatusOK, `
+<!DOCTYPE html>
+<html>
+<head><title>Authorizing…</title></head>
+<body>
+  <p style="font: 16px sans-serif">Authorizing…</p>
+  <button id="ok" style="display:none">Continue</button>
+  <script>
+    var isWebKit = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent);
+    if (isWebKit) {
+        document.getElementById('ok').style.display = 'block';
+        document.getElementById('ok').onclick = function () {
+            window.location.replace('https://crossword-frontend-one.vercel.app/');
+        };
+    } else {
+        window.location.replace('https://crossword-frontend-one.vercel.app/');
+    }
+  </script>
+</body>
+</html>`)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -20,5 +20,5 @@ func RegisterRoutes(r *gin.Engine) {
 	r.GET("/guess/:puzzleId", handlers.AuthMiddleware, handlers.GetGuessHandler)
 	r.POST("/puzzles/:id/validate-guess", handlers.AuthMiddleware, handlers.ValidateGuessHandler)
 	r.DELETE("/puzzles/:id", handlers.AuthMiddleware, handlers.DeletePuzzleHandler)
-	r.GET("/auth/handshake", handlers.HandShakeHandler)
+	r.GET("/handshake", handlers.HandshakeGet)
 }


### PR DESCRIPTION
## Summary
- create a `/handshake` endpoint that serves an HTML page prompting Safari users for a click
- register the new handler in the router
- remove the old auth handshake redirect

## Testing
- `go test ./... -run TestLoginHandler -v 2>&1 | head`
- `go test ./internal/handlers -run TestLoginHandler -v 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6860aa81022483209a7e700f256ada8a